### PR TITLE
fix: keep component props reactive

### DIFF
--- a/src/components/data-display/fds-badge.vue
+++ b/src/components/data-display/fds-badge.vue
@@ -46,7 +46,7 @@
  *
  * @see {@link https://designsystem.dk/komponenter/badges/} DKFDS Badge Documentation
  */
-import { computed } from 'vue'
+import { computed, toRefs } from 'vue'
 
 export interface FdsBadgeProps {
   /**
@@ -65,14 +65,14 @@ export interface FdsBadgeProps {
   variant?: 'success' | 'info' | 'warning' | 'error' | null
 }
 
-const {
-  /** HTML tag to use - 'strong' for emphasis, 'span' for regular badges */
-  tag = 'span',
-  /** Visual variant for different statuses */
-  variant = null,
-} = defineProps<FdsBadgeProps>()
+const props = withDefaults(defineProps<FdsBadgeProps>(), {
+  tag: 'span',
+  variant: null,
+})
 
-const getVariantClass = computed(() => (variant ? `badge-${variant}` : ''))
+const { tag, variant } = toRefs(props)
+
+const getVariantClass = computed(() => (variant.value ? `badge-${variant.value}` : ''))
 </script>
 
 <style scoped lang="scss"></style>

--- a/src/components/data-display/fds-card-group.vue
+++ b/src/components/data-display/fds-card-group.vue
@@ -66,7 +66,7 @@
  *
  * @see {@link https://designsystem.dk/komponenter/cards/} DKFDS Card Documentation
  */
-import { computed } from 'vue'
+import { computed, toRefs } from 'vue'
 
 export interface FdsCardGroupProps {
   /**
@@ -80,7 +80,11 @@ export interface FdsCardGroupProps {
   type?: 'deck' | 'columns' | null
 }
 
-const { type = null } = defineProps<FdsCardGroupProps>()
+const props = withDefaults(defineProps<FdsCardGroupProps>(), {
+  type: null,
+})
 
-const getClass = computed(() => type ?? 'normal')
+const { type } = toRefs(props)
+
+const getClass = computed(() => type.value ?? 'normal')
 </script>

--- a/src/components/data-display/fds-card.vue
+++ b/src/components/data-display/fds-card.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script setup lang="ts">
-import { inject, computed } from 'vue'
+import { inject, computed, toRefs } from 'vue'
 import type { Component } from 'vue'
 import FdsIkon from '../layout/fds-ikon.vue'
 
@@ -171,21 +171,12 @@ export interface FdsCardProps {
  *
  * @see {@link https://designsystem.dk/komponenter/cards/} DKFDS Card Documentation
  */
-const {
-  /** Overskrift */
-  header = undefined,
-  headerTag = 'h2',
-  /** Under overskrift */
-  subheader = undefined,
-  /** Link for navigation card - supports both regular URLs and Vue Router locations */
-  to = undefined,
-  /** Force use of standard anchor tag even if Vue Router is available */
-  external = false,
-  /** Icon for navigation card (e.g., 'arrow-forward', 'open-in-new') */
-  icon = undefined,
-  /** Card variant */
-  variant = undefined,
-} = defineProps<FdsCardProps>()
+const props = withDefaults(defineProps<FdsCardProps>(), {
+  headerTag: 'h2',
+  external: false,
+})
+
+const { header, headerTag, subheader, to, external, icon, variant } = toRefs(props)
 
 // Check if Vue Router is available
 const $router = inject<any>('$router', null)
@@ -199,13 +190,13 @@ const hasRouter = computed(() => {
 // Determine if the link is external
 const isExternalLink = computed(() => {
   // If explicitly set as external, respect that
-  if (external) return true
+  if (external.value) return true
 
   // If not a string, it's a router location object (internal)
-  if (typeof to !== 'string') return false
+  if (typeof to.value !== 'string') return false
 
   // Check for various external URL patterns
-  const url = to as string
+  const url = to.value as string
 
   // Common protocol patterns for external links
   if (url.startsWith('http://') || url.startsWith('https://')) return true
@@ -253,21 +244,20 @@ const getLinkProps = () => {
   const isAnchor = getLinkComponent() === 'a'
 
   if (isAnchor) {
-    return { href: to }
-  } else {
-    return { to }
+    return { href: to.value }
   }
+  return { to: to.value }
 }
 
 // Determine the icon to use based on link type
 const getIcon = computed(() => {
   // If icon is explicitly set, use it
-  if (icon !== undefined) {
-    return icon
+  if (icon.value !== undefined) {
+    return icon.value
   }
 
   // If there's a link, provide smart defaults
-  if (to) {
+  if (to.value) {
     // External links get open-in-new icon by default
     if (isExternalLink.value) {
       return 'open-in-new'

--- a/src/components/data-display/fds-detaljer.vue
+++ b/src/components/data-display/fds-detaljer.vue
@@ -71,6 +71,8 @@
  *
  * @see {@link https://designsystem.dk/komponenter/detaljer/} DKFDS Details Documentation
  */
+import { toRefs } from 'vue'
+
 export interface FdsDetaljerProps {
   /**
    * Header text displayed in the clickable summary area
@@ -80,8 +82,9 @@ export interface FdsDetaljerProps {
   header?: string
 }
 
-const {
-  /** Overskrift */
-  header = 'Mere information',
-} = defineProps<FdsDetaljerProps>()
+const props = withDefaults(defineProps<FdsDetaljerProps>(), {
+  header: 'Mere information',
+})
+
+const { header } = toRefs(props)
 </script>

--- a/src/components/data-display/fds-list-item.vue
+++ b/src/components/data-display/fds-list-item.vue
@@ -62,7 +62,7 @@
  *
  * @see {@link https://designsystem.dk/komponenter/lister/} DKFDS List Documentation
  */
-import { computed } from 'vue'
+import { computed, toRefs } from 'vue'
 
 export interface FdsListItemProps {
   /**
@@ -94,21 +94,26 @@ export interface FdsListItemProps {
   justifyBetween?: boolean
 }
 
-const { variant, role, flex = false, justifyBetween = false } = defineProps<FdsListItemProps>()
+const props = withDefaults(defineProps<FdsListItemProps>(), {
+  flex: false,
+  justifyBetween: false,
+})
+
+const { variant, role, flex, justifyBetween } = toRefs(props)
 
 const itemClasses = computed(() => {
   const classes: string[] = []
 
   // Status classes
-  if (variant) {
-    classes.push(variant)
+  if (variant.value) {
+    classes.push(variant.value)
   }
 
   // Flex layout classes
-  if (flex) {
+  if (flex.value) {
     classes.push('d-flex')
   }
-  if (justifyBetween) {
+  if (justifyBetween.value) {
     classes.push('justify-content-between')
   }
 

--- a/src/components/data-display/fds-preview-code.vue
+++ b/src/components/data-display/fds-preview-code.vue
@@ -52,6 +52,8 @@
  *
  * @see {@link https://designsystem.dk/komponenter/} DKFDS Documentation
  */
+import { toRefs } from 'vue'
+
 export interface FdsPreviewCodeProps {
   /**
    * Optional header text for the code section
@@ -61,5 +63,9 @@ export interface FdsPreviewCodeProps {
   header?: string | null
 }
 
-const { header = null } = defineProps<FdsPreviewCodeProps>()
+const props = withDefaults(defineProps<FdsPreviewCodeProps>(), {
+  header: null,
+})
+
+const { header } = toRefs(props)
 </script>

--- a/src/components/data-display/fds-preview.vue
+++ b/src/components/data-display/fds-preview.vue
@@ -64,6 +64,8 @@
  *
  * @see {@link https://designsystem.dk/komponenter/} DKFDS Documentation
  */
+import { toRefs } from 'vue'
+
 export interface FdsPreviewProps {
   /**
    * Header text describing the component or example being previewed
@@ -83,7 +85,11 @@ export interface FdsPreviewProps {
   linkText?: string
 }
 
-const { header, href, linkText = 'Design System' } = defineProps<FdsPreviewProps>()
+const props = withDefaults(defineProps<FdsPreviewProps>(), {
+  linkText: 'Design System',
+})
+
+const { header, href, linkText } = toRefs(props)
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/data-display/fds-tag.vue
+++ b/src/components/data-display/fds-tag.vue
@@ -62,7 +62,7 @@
  */
 
 import { formId } from '../../composables'
-import { computed, useSlots } from 'vue'
+import { computed, useSlots, toRefs } from 'vue'
 import FdsIkon from '../layout/fds-ikon.vue'
 
 export interface FdsTagProps {
@@ -80,7 +80,8 @@ export interface FdsTagProps {
   id?: string
 }
 
-const { icon, id } = defineProps<FdsTagProps>()
+const props = defineProps<FdsTagProps>()
+const { icon, id } = toRefs(props)
 
 const slots = useSlots()
 
@@ -93,10 +94,10 @@ const emit = defineEmits<{
   click: [formId: string]
 }>()
 
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 
 // Check if tag has an icon (either via prop or slot)
-const hasIcon = computed(() => icon || slots.icon)
+const hasIcon = computed(() => icon.value || slots.icon)
 
 /**
  * Handle click events on the tag button

--- a/src/components/feedback/fds-alert.vue
+++ b/src/components/feedback/fds-alert.vue
@@ -83,7 +83,7 @@
  *
  * @see {@link https://designsystem.dk/komponenter/beskeder/} DKFDS Alert Documentation
  */
-import { ref, computed } from 'vue'
+import { ref, computed, toRefs } from 'vue'
 import FdsIkon from '../layout/fds-ikon.vue'
 
 export interface FdsAlertProps {
@@ -115,12 +115,14 @@ export interface FdsAlertProps {
   closeable?: boolean
 }
 
-const {
-  header = null,
-  variant = 'info',
-  showIcon = false,
-  closeable = false,
-} = defineProps<FdsAlertProps>()
+const props = withDefaults(defineProps<FdsAlertProps>(), {
+  header: null,
+  variant: 'info' as const,
+  showIcon: false,
+  closeable: false,
+})
+
+const { header, variant, showIcon, closeable } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -132,7 +134,7 @@ const emit = defineEmits<{
 
 const showAlert = ref(true)
 
-const compAlert = computed(() => ['warning', 'error'].includes(variant))
+const compAlert = computed(() => ['warning', 'error'].includes(variant.value))
 
 const iconAriaLabel = computed(() => {
   const labels = {
@@ -141,7 +143,7 @@ const iconAriaLabel = computed(() => {
     warning: 'Advarsel',
     error: 'Fejl',
   }
-  return labels[variant]
+  return labels[variant.value]
 })
 
 const onClose = () => {

--- a/src/components/feedback/fds-fejlopsummering.vue
+++ b/src/components/feedback/fds-fejlopsummering.vue
@@ -75,7 +75,7 @@
  *
  * @see {@link https://designsystem.dk/komponenter/fejlopsummering/} DKFDS Error Summary Documentation
  */
-import { computed, provide, ref, onMounted, onUnmounted, toValue } from 'vue'
+import { computed, provide, ref, onMounted, onUnmounted, toRefs, toValue } from 'vue'
 import { generateId } from '../../composables'
 import FdsIkon from '../layout/fds-ikon.vue'
 
@@ -114,16 +114,13 @@ export interface FdsFejlopsummeringProps {
   autoCollect?: boolean
 }
 
-const {
-  /** Overskrift for fejlopsummering */
-  header = 'Der er problemer',
-  /** ID for accessibility aria-labelledby */
-  id,
-  /** Manuel liste af fejl */
-  errors = [],
-  /** Om komponenten automatisk skal indsamle fejl fra formfelter */
-  autoCollect = true,
-} = defineProps<FdsFejlopsummeringProps>()
+const props = withDefaults(defineProps<FdsFejlopsummeringProps>(), {
+  header: 'Der er problemer',
+  errors: () => [],
+  autoCollect: true,
+})
+
+const { header, id, errors, autoCollect } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -134,7 +131,7 @@ const emit = defineEmits<{
 }>()
 
 // Generate unique ID for heading
-const generatedId = generateId(id)
+const generatedId = generateId(id.value)
 const headingId = computed(() => toValue(generatedId))
 
 // Store for collected errors
@@ -142,9 +139,9 @@ const collectedErrors = ref<Map<string, ErrorItem>>(new Map())
 
 // Combine manual errors with collected errors
 const allErrors = computed(() => {
-  const errorList: ErrorItem[] = [...errors]
+  const errorList: ErrorItem[] = [...errors.value]
 
-  if (autoCollect) {
+  if (autoCollect.value) {
     collectedErrors.value.forEach((error) => {
       errorList.push(error)
     })
@@ -158,14 +155,14 @@ const hasErrors = computed(() => allErrors.value.length > 0)
 
 // Function to register an error (for child components to use)
 const registerError = (id: string, message: string, element?: HTMLElement) => {
-  if (!autoCollect) return
+  if (!autoCollect.value) return
 
   collectedErrors.value.set(id, { id, message, element })
 }
 
 // Function to unregister an error
 const unregisterError = (id: string) => {
-  if (!autoCollect) return
+  if (!autoCollect.value) return
 
   collectedErrors.value.delete(id)
 }

--- a/src/components/feedback/fds-modal.vue
+++ b/src/components/feedback/fds-modal.vue
@@ -104,7 +104,7 @@
  */
 
 import { generateId } from '../../composables'
-import { computed, ref, onMounted } from 'vue'
+import { computed, ref, onMounted, toRefs } from 'vue'
 import FdsIkon from '../layout/fds-ikon.vue'
 
 export interface FdsModalProps {
@@ -135,13 +135,13 @@ export interface FdsModalProps {
   cancelText?: string
 }
 
-const {
-  header,
-  id,
-  closeable = true,
-  acceptText = 'Godkend',
-  cancelText = 'Annuller',
-} = defineProps<FdsModalProps>()
+const props = withDefaults(defineProps<FdsModalProps>(), {
+  closeable: true,
+  acceptText: 'Godkend',
+  cancelText: 'Annuller',
+})
+
+const { header, id, closeable, acceptText, cancelText } = toRefs(props)
 
 const emit = defineEmits<{
   close: []
@@ -150,7 +150,7 @@ const emit = defineEmits<{
 }>()
 
 const refDialog = ref(null)
-const dialogId = generateId(id)
+const dialogId = generateId(id.value)
 const htmlDialog = computed(() => refDialog.value as unknown as HTMLDialogElement)
 
 const showModal = () => {
@@ -167,7 +167,7 @@ defineExpose({
 })
 
 onMounted(() => {
-  if (closeable) {
+  if (closeable.value) {
     // cancel is exposed by HTMLDialogElement
     htmlDialog.value.addEventListener('cancel', () => {
       hideModal()

--- a/src/components/forms/fds-fejlmeddelelse.vue
+++ b/src/components/forms/fds-fejlmeddelelse.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, useSlots, isRef, type Ref, watch, onUnmounted } from 'vue'
+import { computed, inject, useSlots, isRef, toRefs, type Ref, watch, onUnmounted } from 'vue'
 
 /**
  * Error message component implementing DKFDS v11 error display specifications.
@@ -64,7 +64,11 @@ export interface FdsFejlmeddelelseProps {
   id?: string
 }
 
-const { auto = true, id } = defineProps<FdsFejlmeddelelseProps>()
+const props = withDefaults(defineProps<FdsFejlmeddelelseProps>(), {
+  auto: true,
+})
+
+const { auto, id } = toRefs(props)
 
 const slots = useSlots()
 
@@ -79,7 +83,7 @@ const errorSummary = inject<{
 } | null>('errorSummary', null)
 
 const compErrorMessage = computed(() => {
-  if (!auto) {
+  if (!auto.value) {
     return null
   }
   const isValid = isRef(injIsValid) ? injIsValid.value : injIsValid
@@ -122,7 +126,7 @@ const displayedError = computed(() => {
 
 // Get the computed ID for the error element
 const computedId = computed(() => {
-  if (id) return id
+  if (id.value) return id.value
   if (errorId) {
     return isRef(errorId) ? errorId.value : errorId
   }

--- a/src/components/forms/fds-formgroup.vue
+++ b/src/components/forms/fds-formgroup.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, provide, ref } from 'vue'
+import { computed, inject, provide, ref, toRefs } from 'vue'
 import { formId } from '../../composables'
 
 /**
@@ -70,13 +70,17 @@ export interface FdsFormgroupProps {
   isValid?: boolean
 }
 
-const { id, isValid = true } = defineProps<FdsFormgroupProps>()
+const props = withDefaults(defineProps<FdsFormgroupProps>(), {
+  isValid: true,
+})
+
+const { id, isValid } = toRefs(props)
 
 /**
  * Form id der bruges i slots
  * eg. label for input element
  */
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 
 /**
  * Generate IDs for hint and error elements following DKFDS v11 naming conventions
@@ -121,7 +125,7 @@ const injIsValid = ref<boolean | null>(inject('provideIsValid', null))
  * Computed validation state that considers both local prop and injected state
  * Prioritizes injected state for form-wide validation coordination
  */
-const compValid = computed(() => injIsValid.value ?? isValid)
+const compValid = computed(() => injIsValid.value ?? isValid.value)
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/forms/fds-label.vue
+++ b/src/components/forms/fds-label.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, isRef, type Ref } from 'vue'
+import { computed, inject, isRef, toRefs, type Ref } from 'vue'
 import { formId } from '../../composables'
 
 /**
@@ -77,16 +77,17 @@ export interface FdsLabelProps {
   requiredText?: string
 }
 
-const {
-  forId,
-  required = false,
-  showRequired = true,
-  requiredText = '(skal udfyldes)',
-} = defineProps<FdsLabelProps>()
+const props = withDefaults(defineProps<FdsLabelProps>(), {
+  required: false,
+  showRequired: true,
+  requiredText: '(skal udfyldes)',
+})
+
+const { forId, required, showRequired, requiredText } = toRefs(props)
 
 // Try to get form ID from formgroup context first, then use prop, then generate
 const injectedFormId = inject<string | Ref<string> | undefined>('formid', undefined)
-const { formid } = formId(forId)
+const { formid } = formId(forId.value)
 
 const computedFor = computed((): string => {
   // Use injected formid from formgroup if available

--- a/src/components/input/fds-checkbox.vue
+++ b/src/components/input/fds-checkbox.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useAttrs, useSlots, inject, isRef, type Ref } from 'vue'
+import { computed, useAttrs, useSlots, inject, isRef, toRefs, type Ref } from 'vue'
 import { formId } from '../../composables'
 
 /**
@@ -109,13 +109,13 @@ export interface FdsCheckboxProps {
   disabled?: boolean
 }
 
-const {
-  id,
-  modelValue = false,
-  value = true,
-  name,
-  disabled = false,
-} = defineProps<FdsCheckboxProps>()
+const props = withDefaults(defineProps<FdsCheckboxProps>(), {
+  modelValue: false,
+  value: true,
+  disabled: false,
+})
+
+const { id, modelValue, value, name, disabled } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -135,7 +135,7 @@ const emit = defineEmits<{
   change: [event: Event]
 }>()
 
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 
 // Check if content slot is provided
 const hasContent = computed(() => !!slots.content)
@@ -169,13 +169,13 @@ const checkboxClass = computed((): string => {
  * Determine if checkbox is checked
  */
 const isChecked = computed((): boolean => {
-  if (Array.isArray(modelValue)) {
-    return modelValue.includes(value as string)
+  if (Array.isArray(modelValue.value)) {
+    return modelValue.value.includes(value.value as string)
   }
-  if (typeof modelValue === 'boolean') {
-    return modelValue
+  if (typeof modelValue.value === 'boolean') {
+    return modelValue.value
   }
-  return modelValue === value
+  return modelValue.value === value.value
 })
 
 /**
@@ -185,14 +185,14 @@ const handleChange = (event: Event) => {
   const target = event.target as HTMLInputElement
   const checked = target.checked
 
-  if (Array.isArray(modelValue)) {
-    const newValue = [...modelValue]
+  if (Array.isArray(modelValue.value)) {
+    const newValue = [...modelValue.value]
     if (checked) {
-      if (!newValue.includes(value as string)) {
-        newValue.push(value as string)
+      if (!newValue.includes(value.value as string)) {
+        newValue.push(value.value as string)
       }
     } else {
-      const index = newValue.indexOf(value as string)
+      const index = newValue.indexOf(value.value as string)
       if (index > -1) {
         newValue.splice(index, 1)
       }

--- a/src/components/input/fds-dato-felter.vue
+++ b/src/components/input/fds-dato-felter.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, toRefs, watch } from 'vue'
 import { formId } from '../../composables'
 
 /**
@@ -126,11 +126,11 @@ export interface FdsDatoFelterProps {
   modelValue?: string
 }
 
-const {
-  id,
-  /** JSON Date */
-  modelValue = '',
-} = defineProps<FdsDatoFelterProps>()
+const props = withDefaults(defineProps<FdsDatoFelterProps>(), {
+  modelValue: '',
+})
+
+const { id, modelValue } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -186,8 +186,8 @@ const getModelDate = (dateString: string) => {
   return { day: '', month: '', year: '' }
 }
 
-const { formid } = formId(id, true)
-const dateObj = ref<{ day: string; month: string; year: string }>(getModelDate(modelValue))
+const { formid } = formId(id.value, true)
+const dateObj = ref<{ day: string; month: string; year: string }>(getModelDate(modelValue.value))
 
 const onInput = () => {
   // Zero-pad values for proper date format (only if not empty)
@@ -230,7 +230,7 @@ let isUserTyping = false
 
 // Watch for modelValue changes from parent
 watch(
-  () => modelValue,
+  modelValue,
   (newValue) => {
     // Don't update while user is typing
     if (isUserTyping) {

--- a/src/components/input/fds-dato-vaelger.vue
+++ b/src/components/input/fds-dato-vaelger.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, toRefs, watch } from 'vue'
 import { formId } from '../../composables'
 
 /**
@@ -71,7 +71,11 @@ export interface FdsDatoVaelgerProps {
   modelValue?: string
 }
 
-const { id, modelValue = '' } = defineProps<FdsDatoVaelgerProps>()
+const props = withDefaults(defineProps<FdsDatoVaelgerProps>(), {
+  modelValue: '',
+})
+
+const { id, modelValue } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -90,8 +94,14 @@ const emit = defineEmits<{
    */
   valid: [isValid: boolean]
 }>()
-const { formid } = formId(id, true)
-const refValue = ref(modelValue)
+const { formid } = formId(id.value, true)
+const refValue = ref(modelValue.value)
+
+watch(modelValue, (newValue) => {
+  if (newValue !== refValue.value) {
+    refValue.value = newValue
+  }
+})
 
 const isDateValid = (dateString: string) => {
   // First check if it's parseable

--- a/src/components/input/fds-dropdown.vue
+++ b/src/components/input/fds-dropdown.vue
@@ -15,7 +15,7 @@
 
 <script setup lang="ts">
 import { formId } from '../../composables'
-import { ref, computed } from 'vue'
+import { ref, computed, toRefs } from 'vue'
 
 /**
  * Dropdown select component implementing DKFDS v11 select field specifications.
@@ -81,7 +81,11 @@ export interface FdsDropdownProps {
   modelValue?: string
 }
 
-const { id, modelValue = '' } = defineProps<FdsDropdownProps>()
+const props = withDefaults(defineProps<FdsDropdownProps>(), {
+  modelValue: '',
+})
+
+const { id, modelValue } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -101,13 +105,13 @@ const emit = defineEmits<{
   change: [event: Event]
 }>()
 
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 const refElement = ref(null)
 const dirty = ref(false)
 
 // Create a computed property for v-model binding
 const selectedValue = computed({
-  get: () => modelValue,
+  get: () => modelValue.value,
   set: (value: string) => emit('update:modelValue', value),
 })
 

--- a/src/components/input/fds-file-upload.vue
+++ b/src/components/input/fds-file-upload.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, toRefs } from 'vue'
 
 import { formId } from '../../composables'
 import { removeBrowserFileContentHeaders } from '../../utils'
@@ -250,27 +250,48 @@ export interface FdsFileUploadProps {
   removeFileText?: string
 }
 
+const props = withDefaults(defineProps<FdsFileUploadProps>(), {
+  name: '',
+  label: 'Vælg fil',
+  showLabel: true,
+  hint: '',
+  accept: () => ['image/png', 'image/jpg', 'image/jpeg', '.pdf', '.doc', '.docx', '.odt'],
+  multiple: false,
+  maxFileSize: 5242880,
+  maxFiles: 10,
+  disabled: false,
+  required: false,
+  error: '',
+  removeContentHeaders: false,
+  showFileList: true,
+  removable: true,
+  requiredText: 'Obligatorisk felt',
+  ariaLive: 'polite' as const,
+  fileListAriaLabel: 'Valgte filer',
+  removeFileText: 'Fjern fil',
+})
+
 const {
   id,
-  name = '',
-  label = 'Vælg fil',
-  showLabel = true,
-  hint = '',
-  accept = ['image/png', 'image/jpg', 'image/jpeg', '.pdf', '.doc', '.docx', '.odt'],
-  multiple = false,
-  maxFileSize = 5242880, // 5MB
-  maxFiles = 10,
-  disabled = false,
-  required = false,
-  error = '',
-  removeContentHeaders = false,
-  showFileList = true,
-  removable = true,
-  requiredText = 'Obligatorisk felt',
-  ariaLive = 'polite',
-  fileListAriaLabel = 'Valgte filer',
-  removeFileText = 'Fjern fil',
-} = defineProps<FdsFileUploadProps>()
+  name,
+  label,
+  showLabel,
+  hint,
+  accept,
+  multiple,
+  maxFileSize,
+  maxFiles,
+  disabled,
+  required,
+  error,
+  removeContentHeaders,
+  showFileList,
+  removable,
+  requiredText,
+  ariaLive,
+  fileListAriaLabel,
+  removeFileText,
+} = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -305,17 +326,17 @@ const emit = defineEmits<{
   'remove-file': [index: number, file: File]
 }>()
 
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 const selectedFiles = ref<File[]>([])
 const isDirty = ref(false)
-const hintId = computed(() => (hint ? `${formid.value}-hint` : undefined))
+const hintId = computed(() => (hint.value ? `${formid.value}-hint` : undefined))
 const errorId = computed(() => (hasError.value ? `${formid.value}-error` : undefined))
 
-const acceptedTypes = computed(() => accept.join(','))
+const acceptedTypes = computed(() => accept.value.join(','))
 
-const hasError = computed(() => Boolean(error))
+const hasError = computed(() => Boolean(error.value))
 
-const errorMessage = computed(() => error)
+const errorMessage = computed(() => error.value)
 
 const inputClasses = computed(() => ({
   'form-control': true,
@@ -353,19 +374,19 @@ const validateFile = (
   file: File,
 ): { valid: boolean; error?: { type: string; message: string } } => {
   // Check file size
-  if (file.size > maxFileSize) {
+  if (file.size > maxFileSize.value) {
     return {
       valid: false,
       error: {
         type: 'size',
-        message: `Filen "${file.name}" er for stor. Maksimal størrelse er ${formatFileSize(maxFileSize)}.`,
+        message: `Filen "${file.name}" er for stor. Maksimal størrelse er ${formatFileSize(maxFileSize.value)}.`,
       },
     }
   }
 
   // Check file type if specified
-  if (accept.length > 0) {
-    const isValidType = accept.some((acceptedType) => {
+  if (accept.value.length > 0) {
+    const isValidType = accept.value.some((acceptedType) => {
       if (acceptedType.startsWith('.')) {
         return file.name.toLowerCase().endsWith(acceptedType.toLowerCase())
       }
@@ -377,7 +398,7 @@ const validateFile = (
         valid: false,
         error: {
           type: 'type',
-          message: `Filen "${file.name}" har et ikke-understøttet format. Tilladte formater: ${accept.join(', ')}.`,
+          message: `Filen "${file.name}" har et ikke-understøttet format. Tilladte formater: ${accept.value.join(', ')}.`,
         },
       }
     }
@@ -412,10 +433,10 @@ const processFiles = async (files: File[]) => {
   }
 
   // Check total file count
-  if (selectedFiles.value.length + validFiles.length > maxFiles) {
+  if (selectedFiles.value.length + validFiles.length > maxFiles.value) {
     emit('error', {
       type: 'count',
-      message: `Du kan maksimalt vælge ${maxFiles} filer.`,
+      message: `Du kan maksimalt vælge ${maxFiles.value} filer.`,
     })
     return
   }
@@ -430,7 +451,7 @@ const processFiles = async (files: File[]) => {
         reader.readAsDataURL(file)
       })
 
-      const data = removeContentHeaders ? removeBrowserFileContentHeaders(result) : result
+      const data = removeContentHeaders.value ? removeBrowserFileContentHeaders(result) : result
 
       const fileModel: FdsFileInputModel = {
         filename: file.name,

--- a/src/components/input/fds-input-number.vue
+++ b/src/components/input/fds-input-number.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useAttrs, inject, isRef, type Ref } from 'vue'
+import { computed, useAttrs, inject, isRef, toRefs, type Ref } from 'vue'
 import { formId } from '../../composables'
 
 /**
@@ -133,16 +133,12 @@ export interface FdsInputNumberProps {
   widthClass?: string
 }
 
-const {
-  id,
-  modelValue = '',
-  suffix,
-  prefix,
-  min,
-  max,
-  step,
-  widthClass = '',
-} = defineProps<FdsInputNumberProps>()
+const props = withDefaults(defineProps<FdsInputNumberProps>(), {
+  modelValue: '',
+  widthClass: '',
+})
+
+const { id, modelValue, suffix, prefix, min, max, step, widthClass } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -162,7 +158,7 @@ const emit = defineEmits<{
   input: [event: Event]
 }>()
 
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 
 // Inject aria-describedby from formgroup if available
 const injectedAriaDescribedby = inject<string | Ref<string> | undefined>(
@@ -187,9 +183,9 @@ const computedAriaDescribedby = computed((): string | undefined => {
 const wrapperClass = computed((): string => {
   const classes: string[] = []
 
-  if (suffix) {
+  if (suffix.value) {
     classes.push('form-input-wrapper', 'form-input-wrapper--suffix')
-  } else if (prefix) {
+  } else if (prefix.value) {
     classes.push('form-input-wrapper', 'form-input-wrapper--prefix')
   }
 
@@ -202,8 +198,8 @@ const wrapperClass = computed((): string => {
 const inputClass = computed((): string => {
   const classes = ['form-input']
 
-  if (widthClass) {
-    classes.push(widthClass)
+  if (widthClass.value) {
+    classes.push(widthClass.value)
   }
 
   return classes.join(' ')
@@ -211,7 +207,7 @@ const inputClass = computed((): string => {
 
 const inputValue = computed({
   get() {
-    return modelValue
+    return modelValue.value
   },
   set(newValue) {
     emit('update:modelValue', newValue)

--- a/src/components/input/fds-input.vue
+++ b/src/components/input/fds-input.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useSlots, useAttrs, inject, isRef, type Ref } from 'vue'
+import { computed, useSlots, useAttrs, inject, isRef, toRefs, type Ref } from 'vue'
 import { formId } from '../../composables'
 
 /**
@@ -125,14 +125,13 @@ export interface FdsInputProps {
   widthClass?: string
 }
 
-const {
-  id,
-  modelValue = '',
-  suffix,
-  prefix,
-  type = 'text',
-  widthClass = '',
-} = defineProps<FdsInputProps>()
+const props = withDefaults(defineProps<FdsInputProps>(), {
+  modelValue: '',
+  type: 'text',
+  widthClass: '',
+})
+
+const { id, modelValue, suffix, prefix, type, widthClass } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -155,7 +154,7 @@ const emit = defineEmits<{
 }>()
 const slots = useSlots()
 
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 
 // Inject aria-describedby from formgroup if available
 const injectedAriaDescribedby = inject<string | Ref<string> | undefined>(
@@ -180,9 +179,9 @@ const computedAriaDescribedby = computed((): string | undefined => {
 const wrapperClass = computed((): string => {
   const classes: string[] = []
 
-  if (suffix) {
+  if (suffix.value) {
     classes.push('form-input-wrapper', 'form-input-wrapper--suffix')
-  } else if (prefix) {
+  } else if (prefix.value) {
     classes.push('form-input-wrapper', 'form-input-wrapper--prefix')
   } else if (slots.button) {
     classes.push('search')
@@ -197,8 +196,8 @@ const wrapperClass = computed((): string => {
 const inputClass = computed((): string => {
   const classes = ['form-input']
 
-  if (widthClass) {
-    classes.push(widthClass)
+  if (widthClass.value) {
+    classes.push(widthClass.value)
   }
 
   return classes.join(' ')
@@ -206,7 +205,7 @@ const inputClass = computed((): string => {
 
 const inputValue = computed({
   get() {
-    return modelValue
+    return modelValue.value
   },
   set(newValue) {
     emit('update:modelValue', newValue)

--- a/src/components/input/fds-radio-group.vue
+++ b/src/components/input/fds-radio-group.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup lang="ts">
-import { provide, computed, useSlots } from 'vue'
+import { provide, computed, useSlots, toRefs } from 'vue'
 import { formId } from '../../composables'
 
 /**
@@ -99,7 +99,11 @@ export interface FdsRadioGroupProps {
   name?: string
 }
 
-const { modelValue, id, label, helpText = '', name } = defineProps<FdsRadioGroupProps>()
+const props = withDefaults(defineProps<FdsRadioGroupProps>(), {
+  helpText: '',
+})
+
+const { modelValue, id, label, helpText, name } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -115,16 +119,16 @@ const emit = defineEmits<{
 }>()
 
 const slots = useSlots()
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 
 // Generate IDs for accessibility
 const legendId = computed(() => `${formid.value}-legend`)
-const helpTextId = computed(() => (helpText || slots.help ? `${formid.value}-help` : undefined))
+const helpTextId = computed(() => (helpText.value || slots.help ? `${formid.value}-help` : undefined))
 
 // Provide radio name to children
-const radioName = computed(() => name || `radio-${formid.value}`)
+const radioName = computed(() => name.value || `radio-${formid.value}`)
 
-const value = computed(() => modelValue)
+const value = computed(() => modelValue.value)
 
 const exposeEmit = (newValue: string | number | boolean) => {
   emit('update:modelValue', newValue)

--- a/src/components/input/fds-radio-item.vue
+++ b/src/components/input/fds-radio-item.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, useSlots, isRef, type Ref } from 'vue'
+import { computed, inject, useSlots, isRef, toRefs, type Ref } from 'vue'
 import { formId, generateId } from '../../composables'
 
 /**
@@ -112,7 +112,11 @@ export interface FdsRadioItemProps {
   name?: string
 }
 
-const { value, index, id, disabled = false, name } = defineProps<FdsRadioItemProps>()
+const props = withDefaults(defineProps<FdsRadioItemProps>(), {
+  disabled: false,
+})
+
+const { value, index, id, disabled, name } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -136,8 +140,8 @@ const injGroupValue = inject<
 >('provideGroupValue', null)
 const injGroupName = inject<Ref<string> | string>('provideGroupName', '')
 
-const { formid } = formId(id, true)
-const indexIdRef = generateId(index)
+const { formid } = formId(id.value, true)
+const indexIdRef = generateId(index.value)
 const indexId = indexIdRef ? indexIdRef.value : 'item'
 
 // Generate unique radio ID
@@ -146,7 +150,7 @@ const radioId = computed(() => `radio-${formid.value}-${indexId}`)
 // Use injected name or prop name
 const radioName = computed(() => {
   const groupName = isRef(injGroupName) ? injGroupName.value : injGroupName
-  return name || groupName || `radio-${formid.value}`
+  return name.value || groupName || `radio-${formid.value}`
 })
 
 // Check if content slot is provided
@@ -155,7 +159,7 @@ const hasContent = computed(() => !!slots.content)
 // Check if this radio is selected
 const isChecked = computed(() => {
   const groupValue = isRef(injGroupValue) ? injGroupValue.value : injGroupValue
-  return value === groupValue
+  return value.value === groupValue
 })
 
 // Inject aria-describedby from formgroup if available

--- a/src/components/input/fds-textarea.vue
+++ b/src/components/input/fds-textarea.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, isRef, type Ref, useAttrs } from 'vue'
+import { computed, inject, isRef, toRefs, type Ref, useAttrs } from 'vue'
 import { formId } from '../../composables'
 
 /**
@@ -111,15 +111,14 @@ export interface FdsTextareaProps {
   widthClass?: string
 }
 
-const {
-  modelValue,
-  id,
-  rows = 5,
-  maxRows = 10,
-  rowlength = 80,
-  maxlength,
-  widthClass = '',
-} = defineProps<FdsTextareaProps>()
+const props = withDefaults(defineProps<FdsTextareaProps>(), {
+  rows: 5,
+  maxRows: 10,
+  rowlength: 80,
+  widthClass: '',
+})
+
+const { modelValue, id, rows, maxRows, rowlength, maxlength, widthClass } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -139,7 +138,7 @@ const emit = defineEmits<{
   input: [event: Event]
 }>()
 
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 
 // Inject aria-describedby from formgroup if available
 const injectedAriaDescribedby = inject<string | Ref<string> | undefined>(
@@ -165,8 +164,8 @@ const computedAriaDescribedby = computed((): string | undefined => {
 const textareaClass = computed((): string => {
   const classes = ['form-input']
 
-  if (widthClass) {
-    classes.push(widthClass)
+  if (widthClass.value) {
+    classes.push(widthClass.value)
   }
 
   return classes.join(' ')
@@ -176,23 +175,23 @@ const textareaClass = computed((): string => {
  * Calculate dynamic rows based on content
  */
 const getRows = computed(() => {
-  if (!modelValue) {
-    return rows
+  if (!modelValue.value) {
+    return rows.value
   }
-  const newlineRows = modelValue.split(/\r?\n/).length
+  const newlineRows = modelValue.value.split(/\r?\n/).length
 
-  const textLengthRow = Math.floor(modelValue.length / rowlength) + 1
+  const textLengthRow = Math.floor(modelValue.value.length / rowlength.value) + 1
   const result = newlineRows > textLengthRow ? newlineRows : textLengthRow
 
-  if (result < maxRows) {
-    return result < rows ? rows : result
+  if (result < maxRows.value) {
+    return result < rows.value ? rows.value : result
   }
-  return maxRows
+  return maxRows.value
 })
 
 const inputValue = computed({
   get() {
-    return modelValue
+    return modelValue.value
   },
   set(newValue) {
     emit('update:modelValue', newValue)

--- a/src/components/input/fds-toggle-switch.vue
+++ b/src/components/input/fds-toggle-switch.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, isRef, type Ref } from 'vue'
+import { computed, inject, isRef, toRefs, type Ref } from 'vue'
 import { formId } from '../../composables'
 
 /**
@@ -106,14 +106,15 @@ export interface FdsToggleSwitchProps {
   class?: string
 }
 
-const {
-  id,
-  modelValue = false,
-  disabled = false,
-  offText = 'Fra',
-  onText = 'Til',
-  class: className = '',
-} = defineProps<FdsToggleSwitchProps>()
+const props = withDefaults(defineProps<FdsToggleSwitchProps>(), {
+  modelValue: false,
+  disabled: false,
+  offText: 'Fra',
+  onText: 'Til',
+  class: '',
+})
+
+const { id, modelValue, disabled, offText, onText, class: className } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -128,7 +129,7 @@ const emit = defineEmits<{
   click: [event: MouseEvent]
 }>()
 
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 
 // Inject aria-describedby from formgroup if available
 const injectedAriaDescribedby = inject<string | Ref<string> | undefined>(
@@ -148,8 +149,8 @@ const computedAriaDescribedby = computed((): string | undefined => {
 const toggleSwitchClass = computed((): string => {
   const classes: string[] = []
 
-  if (className) {
-    classes.push(className)
+  if (className.value) {
+    classes.push(className.value)
   }
 
   return classes.join(' ')
@@ -159,9 +160,9 @@ const toggleSwitchClass = computed((): string => {
  * Handle toggle state change
  */
 const handleToggle = (event: MouseEvent) => {
-  if (disabled) return
+  if (disabled.value) return
 
-  const newValue = !modelValue
+  const newValue = !modelValue.value
   emit('update:modelValue', newValue)
   emit('click', event)
 }

--- a/src/components/layout/fds-cookiemeddelelse.vue
+++ b/src/components/layout/fds-cookiemeddelelse.vue
@@ -88,6 +88,8 @@
  *
  * @see {@link https://designsystem.dk/komponenter/cookiemeddelelse/} DKFDS Cookie Notice Documentation
  */
+import { toRefs } from 'vue'
+
 export interface FdsCookiemeddelelseProps {
   /**
    * Header text for the cookie notice
@@ -97,7 +99,11 @@ export interface FdsCookiemeddelelseProps {
   header?: string
 }
 
-const { header = 'Fortæl os om du accepterer cookies' } = defineProps<FdsCookiemeddelelseProps>()
+const props = withDefaults(defineProps<FdsCookiemeddelelseProps>(), {
+  header: 'Fortæl os om du accepterer cookies',
+})
+
+const { header } = toRefs(props)
 
 defineEmits<{
   /**

--- a/src/components/navigation/fds-overflow-menu.vue
+++ b/src/components/navigation/fds-overflow-menu.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, toRefs } from 'vue'
 import { formId } from '../../composables'
 import FdsIkon from '../layout/fds-ikon.vue'
 
@@ -133,12 +133,13 @@ export interface FdsOverflowMenuProps {
   position?: 'left' | 'right'
 }
 
-const {
-  icon = 'more-vert',
-  position = 'right',
-  iconPosition = 'right',
-  id,
-} = defineProps<FdsOverflowMenuProps>()
+const props = withDefaults(defineProps<FdsOverflowMenuProps>(), {
+  icon: 'more-vert',
+  position: 'right' as const,
+  iconPosition: 'right' as const,
+})
+
+const { icon, position, iconPosition, id, header } = toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -160,7 +161,7 @@ const emit = defineEmits<{
   toggle: [isOpen: boolean]
 }>()
 
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 
 const buttonRef = ref<HTMLButtonElement>()
 const menuRef = ref<HTMLDivElement>()
@@ -169,7 +170,7 @@ const isOpen = ref(false)
 const buttonId = computed(() => `button_${formid.value}`)
 const menuId = computed(() => formid.value)
 const positionClass = computed(() => {
-  return position === 'left' ? 'overflow-menu--open-left' : 'overflow-menu--open-right'
+  return position.value === 'left' ? 'overflow-menu--open-left' : 'overflow-menu--open-right'
 })
 
 const open = () => {

--- a/src/components/navigation/fds-trinindikator-group.vue
+++ b/src/components/navigation/fds-trinindikator-group.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, toRefs } from 'vue'
 import { formId } from '../../composables'
 import FdsModal from '../feedback/fds-modal.vue'
 
@@ -188,19 +188,21 @@ export interface FdsTrinindikatorGroupProps {
   closeButtonText?: string
 }
 
-const {
-  id,
-  currentStep = 1,
-  totalSteps = 0,
-  ariaLabel = 'Trinindikator',
-  responsive: _responsive = true,
-  mobileBreakpoint: _mobileBreakpoint = 768,
-  showStepInfo = false,
-  clickableSteps = false,
-  modalTitle = 'Trin',
-  modalAriaLabel: _modalAriaLabel = 'Trin modal',
-  closeButtonText = 'Luk',
-} = defineProps<FdsTrinindikatorGroupProps>()
+const props = withDefaults(defineProps<FdsTrinindikatorGroupProps>(), {
+  currentStep: 1,
+  totalSteps: 0,
+  ariaLabel: 'Trinindikator',
+  responsive: true,
+  mobileBreakpoint: 768,
+  showStepInfo: false,
+  clickableSteps: false,
+  modalTitle: 'Trin',
+  modalAriaLabel: 'Trin modal',
+  closeButtonText: 'Luk',
+})
+
+const { id, currentStep, totalSteps, ariaLabel, showStepInfo, clickableSteps, modalTitle, closeButtonText } =
+  toRefs(props)
 
 const emit = defineEmits<{
   /**
@@ -222,12 +224,12 @@ const emit = defineEmits<{
   'modal-close': []
 }>()
 
-const { formid } = formId(id, true)
+const { formid } = formId(id.value, true)
 const mobileModal = ref<InstanceType<typeof FdsModal> | null>(null)
 
 const stepIndicatorClasses = computed(() => ({
-  'step-indicator--clickable': clickableSteps,
-  'step-indicator--with-info': showStepInfo,
+  'step-indicator--clickable': clickableSteps.value,
+  'step-indicator--with-info': showStepInfo.value,
 }))
 
 const openMobileModal = () => {


### PR DESCRIPTION
## Summary
- wrap component props in `withDefaults(..., toRefs)` so v-model bindings stay reactive across inputs, toggles, and navigation elements
- update computed helpers and event handlers to reference reactive refs for ID generation, validation state, and accessibility wiring
- synchronize components like the date picker and file upload with incoming prop changes using watches and reactive computed values

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cd7836eb388331bfc063264ad5b712